### PR TITLE
db:install Command fix

### DIFF
--- a/src/Command/DatabaseInstallCommand.php
+++ b/src/Command/DatabaseInstallCommand.php
@@ -19,7 +19,7 @@ class DatabaseInstallCommand extends Command
         $port = empty(getenv("DB_PORT")) ? 3306 : getenv("DB_DATABASE");
 
         if (\mysqli_query(
-            \mysqli_connect($host, $user, $password, "", $port),
+            \mysqli_connect($host, $user, $password, "", (int)$port),
             "CREATE DATABASE `$database`"
         )) {
             return $this->info("$database created successfully.");


### PR DESCRIPTION
### db:install Command fix,  
#### Port number to be int rather than string.


```
E:\_Server\www\leafAPI-3.x>php leaf db:install

Warning: mysqli_connect() expects parameter 5 to be int, string given in E:\_Server\www\leafAPI-3.x\vendor\leafs\aloe\src\Command\DatabaseInstallCommand.php on line 22

Warning: mysqli_query() expects parameter 1 to be mysqli, null given in E:\_Server\www\leafAPI-3.x\vendor\leafs\aloe\src\Command\DatabaseInstallCommand.php on line 23
leafApi could not be created.


```