### PR TITLE
LinkCommand to create symbolic link for storage directory

### DIFF
--- a/src/Command/LinkCommand.php
+++ b/src/Command/LinkCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Console;
+
+use Aloe\Command;
+class LinkCommand extends Command
+
+{
+    protected static $defaultName = 'link';
+    public $description = 'Create a symbolic link for the storage directory';
+    public $help = 'Create a symbolic link for the storage directory';
+
+    protected function config()
+    {
+        
+    }
+
+    protected function handle()
+    {
+        $this->writeln('');
+        $this->info('Creating symbolic link for storage directory...');
+        
+        $publicPath = getcwd() . '/public';
+        $storagePath = StoragePath('app/public');
+
+        if (!file_exists($storagePath)) {
+            $this->error('Storage directory does not exist');
+            return;
+        }
+
+        if (!file_exists($publicPath)) {
+            $this->error('Public directory does not exist');
+            return;
+        }
+
+        $this->writeln('');
+
+        if (file_exists("$publicPath/storage")) {
+            $this->error('Symbolic link already exists');
+            return;
+        }
+
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+
+            // convert forward slashes to backslashes
+            $publicPath = str_replace('/', '\\', $publicPath);
+            $storagePath = str_replace('/', '\\', $storagePath);
+
+            $this->writeln(asComment("Experimental: "). "This command is experimental and may not work on Windows");
+            $this->writeln(shell_exec("mklink /J $publicPath\\storage $storagePath"));
+            
+        }else{
+            $this->writeln(shell_exec("ln -s $storagePath $publicPath/storage"));
+        }
+
+        $this->info(PHP_EOL.'Symbolic link created successfully');
+    }
+}

--- a/src/Command/LinkCommand.php
+++ b/src/Command/LinkCommand.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace App\Console;
+namespace Aloe\Command;
 
-use Aloe\Command;
-class LinkCommand extends Command
+class LinkCommand extends \Aloe\Command
 
 {
     protected static $defaultName = 'link';

--- a/src/Console.php
+++ b/src/Console.php
@@ -108,6 +108,9 @@ class Console
             \Aloe\Command\ViewBuildCommand::class,
             \Aloe\Command\ViewDevCommand::class,
             \Aloe\Command\ViewInstallCommand::class,
+
+            // Symbolic link command
+            \Aloe\Command\LinkCommand::class,   
         ];
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

This PR introduces a new command, `LinkCommand`, which creates a symbolic link between the `storage` directory and the `public` directory. This feature simplifies asset management for applications by allowing easy access to storage files via the public directory.

The command checks for platform compatibility (Windows or Unix-based systems) and executes the appropriate linking operation (`ln -s` on Unix or `mklink /J` on Windows). Additionally, it ensures that the necessary directories exist before proceeding and gracefully handles errors like missing directories or existing symbolic links.

### Benefits:
- Allows users to quickly and easily create symbolic links for storage directories.
- Platform-specific support for Windows (using junctions) and Unix-based systems (using symbolic links).
- Improves developer experience by simplifying the storage directory setup.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Related Issue

This feature does not fix an existing issue but was implemented to streamline storage handling in the framework.