### PR TITLE
fix: db install should create file for sqlite

### DIFF
--- a/src/Command/DatabaseInstallCommand.php
+++ b/src/Command/DatabaseInstallCommand.php
@@ -19,6 +19,14 @@ class DatabaseInstallCommand extends Command
         $dbConnection = _env('DB_CONNECTION', 'mysql');
         $port = empty(_env('DB_PORT')) ? 3306 : _env('DB_PORT');
 
+        if ($dbConnection === 'sqlite') {
+            if (!file_exists($database)) {
+                file_put_contents($database, '');
+            }
+            $this->info("$database created successfully.");
+            return 0;
+        }
+
         db()->connect([
             'dbtype' => MvcConfig('database')['connections'][$dbConnection]['driver'] ?? 'mysql',
             'host' => $host,


### PR DESCRIPTION
## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

On a fresh LeafMVC project, if you configure the `.env` file for Sqlite by specifying `DB_CONNECTION=sqlite` and `DB_DATABASE=/absolute/path/to/database.sqlite` and run `php leaf db:install` you'll get a syntax error because Sqlite does not support `CREATE DATABASE`.

The change checks if the configured DB is Sqlite and if so, simply touches the file specified in `DB_DATABASE` if it doesn't exist.

## Does this PR introduce a breaking change? (check one)

- [ ] Yes
- [x] No

## Related Issue
